### PR TITLE
fix:  change add command

### DIFF
--- a/1-your-first-repo/04-git-workflow.sh
+++ b/1-your-first-repo/04-git-workflow.sh
@@ -2,6 +2,6 @@
 # Git Workflow 🔄
 
 git status # before staging
-git add .
+git add file-name # type name of file here
 git commit -m "Initial Commit"
 git status # after staging


### PR DESCRIPTION
## Description 
This PR changes the add command from `git add .` to `git add file-name`, so that users learn the best practice

## Issue

Closes #4 